### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ ifupdown-multi (1.0.1) UNRELEASED; urgency=medium
 
   * Use secure copyright file specification URI.
   * Update standards version to 4.6.0, no changes needed.
+  * Update standards version to 4.6.2, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sat, 30 Jul 2022 22:28:02 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ifupdown-multi (1.0.1) UNRELEASED; urgency=medium
+
+  * Use secure copyright file specification URI.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sat, 30 Jul 2022 22:28:02 -0000
+
 ifupdown-multi (1.0.0) unstable; urgency=medium
 
   * README.md: fix name of multi_gateway_preferred_prefixes option in

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 ifupdown-multi (1.0.1) UNRELEASED; urgency=medium
 
   * Use secure copyright file specification URI.
+  * Update standards version to 4.6.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sat, 30 Jul 2022 22:28:02 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Robert Edmonds <edmonds@debian.org>
 Build-Depends: debhelper-compat (= 13), dh-python, python3
-Standards-Version: 4.5.0
+Standards-Version: 4.6.0
 Vcs-Git: https://github.com/edmonds/ifupdown-multi.git
 Vcs-Browser: https://github.com/edmonds/ifupdown-multi
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Robert Edmonds <edmonds@debian.org>
 Build-Depends: debhelper-compat (= 13), dh-python, python3
-Standards-Version: 4.6.0
+Standards-Version: 4.6.2
 Vcs-Git: https://github.com/edmonds/ifupdown-multi.git
 Vcs-Browser: https://github.com/edmonds/ifupdown-multi
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Source: https://github.com/edmonds/ifupdown-multi
 
 Files: *


### PR DESCRIPTION
Fix some issues reported by lintian

* Use secure copyright file specification URI. ([insecure-copyright-format-uri](https://lintian.debian.org/tags/insecure-copyright-format-uri))
* Update standards version to 4.6.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

These changes have no impact on the [binary debdiff](https://janitor.debian.net/api/run/d2e17aa9-c8b7-4b28-8a6f-e28e7d3b1813/debdiff?filter_boring=1).

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/d2e17aa9-c8b7-4b28-8a6f-e28e7d3b1813/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/d2e17aa9-c8b7-4b28-8a6f-e28e7d3b1813/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/run/d2e17aa9-c8b7-4b28-8a6f-e28e7d3b1813.