### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Browser: https://github.com/edmonds/ifupdown-multi
 
 Package: ifupdown-multi
 Architecture: all
-Depends: python3, ${misc:Depends}, ${python3:Depends}
+Depends: python3:any, ${misc:Depends}, ${python3:Depends}
 Enhances: ifupdown
 Description: multiple default gateway support for ifupdown
  This package integrates support for multiple default gateways on


### PR DESCRIPTION
Apply hints suggested by the multi-arch hinter.

* ifupdown-multi: Add :any qualifier for python3 dependency.. This fixes: ifupdown-multi could have its dependency on python3 annotated with :any. ([dep-any](https://wiki.debian.org/MultiArch/Hints#dep-any))

These changes were suggested on https://wiki.debian.org/MultiArch/Hints.

Note that in some cases, these multi-arch hints may trigger lintian warnings until the dependencies of the package support multi-arch. This is expected, see [https://janitor.debian.net/multiarch-fixes#why-does-lintian-warn](the FAQ) for details.

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/multiarch-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/multiarch-fixes/pkg/ifupdown-multi/aa58c2a6-23cc-406e-b677-126cd06564c6.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Depends: [-python3-] {+python3:any+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/aa58c2a6-23cc-406e-b677-126cd06564c6/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/aa58c2a6-23cc-406e-b677-126cd06564c6/diffoscope)).
